### PR TITLE
[improve][utils] PronotronAnimator fast-forward API, swap-remove ghost-read fix, and IDPool/NativeControlTable performance overhaul

### DIFF
--- a/packages/pronotron-io/CHANGELOG.md
+++ b/packages/pronotron-io/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pronotron/io
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @pronotron/utils@1.1.0
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/pronotron-io/package.json
+++ b/packages/pronotron-io/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pronotron/io",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Reliable viewport tracking without missed targets, unlike the default IntersectionObserver API.",
 	"author": "Yunus Bayraktaroglu <yunus.bayraktaroglu@gmail.com>",
 	"main": "./dist/index.js",
@@ -41,6 +41,6 @@
 		"@pronotron/config-ts": "*"
 	},
 	"dependencies": {
-		"@pronotron/utils": "1.0.1"
+		"@pronotron/utils": "1.1.0"
 	}
 }

--- a/packages/pronotron-io/src/core/PronotronIOBase.ts
+++ b/packages/pronotron-io/src/core/PronotronIOBase.ts
@@ -275,9 +275,6 @@ export abstract class PronotronIOBase<TEvents extends string>
 				[ IONodeStrideIndex.OnFastForward ]: fastForwardOption
 			} );
 
-			// IONode has been created successfully, consume ID
-			this._idPool.consume( internalID );
-
 			// IONode might be added while app is running. Calculate bounds
 			const { nodeStart, nodeEnd } = this._updateNodeBounds( internalID, newNodeOptions );
 

--- a/packages/pronotron-pointer/CHANGELOG.md
+++ b/packages/pronotron-pointer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pronotron/io
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @pronotron/utils@1.1.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/pronotron-pointer/package.json
+++ b/packages/pronotron-pointer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pronotron/pointer",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Tracks mouse and touch pointers with custom states such as holding, tapping, idling, interacting, moving out, and moving in, providing enhanced interaction control.",
 	"author": "Yunus Bayraktaroglu <yunus.bayraktaroglu@gmail.com>",
 	"main": "./dist/index.js",
@@ -40,6 +40,6 @@
 		"@pronotron/config-ts": "*"
 	},
 	"dependencies": {
-		"@pronotron/utils": "1.0.1"
+		"@pronotron/utils": "1.1.0"
 	}
 }

--- a/packages/pronotron-utils/CHANGELOG.md
+++ b/packages/pronotron-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pronotron/utils
 
+## 1.1.0
+
+### Minor Changes
+
+- Added fast-forward support to `PronotronAnimator`.
+- Fixed a ghost memory offset issue in `Animator.tick()`.
+- Improved internal performance of `IDPool`.
+- Implemented allocation-free iteration in `NativeControlTable`.
+- Expanded test coverage.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/pronotron-utils/package.json
+++ b/packages/pronotron-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pronotron/utils",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "A set of helper modules used by other @pronotron packages, which can also be used individually.",
 	"author": "Yunus Bayraktaroglu <yunus.bayraktaroglu@gmail.com>",
 	"main": "./dist/index.js",

--- a/packages/pronotron-utils/src/animator/PronotronAnimator.ts
+++ b/packages/pronotron-utils/src/animator/PronotronAnimator.ts
@@ -243,7 +243,6 @@ export class PronotronAnimator
 		} );
 
 		this._animationClientIDtoInternalID.set( animationOption.id, animationInternalID );
-		this._animationInternalIDsPool.consume( animationInternalID );
 		this._animationReferences[ animationInternalID ] = animationOption;
 	}
 

--- a/packages/pronotron-utils/src/animator/PronotronAnimator.ts
+++ b/packages/pronotron-utils/src/animator/PronotronAnimator.ts
@@ -275,10 +275,10 @@ export class PronotronAnimator
 	 */
 	tick(): void
 	{
-		const { table, usedSlots, stride } = this._controlTable;
+		const { table, stride } = this._controlTable;
 		const { elapsedTime, elapsedPausedTime } = this._clock.getTime();
 		
-		for ( let i = 0; i < usedSlots; i++ ){
+		for ( let i = 0; i < this._controlTable.usedSlots; i++ ){
 		
 			const offset = i * stride;
 			const time = ( table[ offset + AnimationData.TIMESTYLE ] === AnimationTimeStyle.CONTINIOUS ) ? elapsedTime : elapsedPausedTime;
@@ -313,6 +313,7 @@ export class PronotronAnimator
 			if ( time > table[ offset + AnimationData.ENDTIME ] ){
 				animationReference.onEnd?.( false );
 				this._removeAnimationByInternalID( internalID );
+				i--;
 			}
 		}
 	}

--- a/packages/pronotron-utils/src/animator/PronotronAnimator.ts
+++ b/packages/pronotron-utils/src/animator/PronotronAnimator.ts
@@ -1,7 +1,6 @@
 import { PronotronClock } from "../clock/PronotronClock";
 import { NativeControlTable } from "../native-control-table/NativeControlTable";
 import { IDPool } from "../utils/IDPool";
-import { type RequireAtLeastOne } from "../utils/Types";
 
 /**
  * Calculating AnimationData stride with code, causes to make it constant. 
@@ -80,11 +79,6 @@ type RenderableAnimation = {
 	 */
 	onRender: ( currentTime: number, startTime: number, duration: number ) => void;
 	/**
-	 * Optional delay before the animation begins, in seconds. 
-	 * If omitted or `0`, the animation begins immediately when scheduled.
-	 */
-	delay?: number;
-	/**
 	 * Called when the animation finishes.
 	 * @param forced Indicates whether the animation was forcibly terminated (via removeAnimation()).
 	 */
@@ -102,10 +96,6 @@ type RenderableAnimation = {
  * must not expose a render callback.
  */
 type NonRenderableAnimation = {
-	/**
-	 * Delay before animation start, in seconds.
-	 */
-	delay: number;
 	/**
 	 * Called when the animation begins.
 	 */ 
@@ -138,6 +128,11 @@ export type AnimationOption = AnimationType & {
 	 * false → continues ticking
 	 */
 	autoPause: boolean;
+	/**
+	 * Optional delay before the animation begins, in seconds. 
+	 * If omitted or `0`, the animation begins immediately when scheduled.
+	 */
+	delay?: number;
 };
 
 /**
@@ -219,7 +214,7 @@ export class PronotronAnimator
 	 */
 	add( animationOption: AnimationOption ): void
 	{
-		if ( this._controlTable.isExist( animationOption.id ) ){
+		if ( this.has( animationOption.id ) ){
 			this.remove( animationOption.id, true );
 		}
 
@@ -280,6 +275,7 @@ export class PronotronAnimator
 		for ( let i = 0; i < this._controlTable.usedSlots; i++ ){
 		
 			const offset = i * stride;
+			
 			const time = ( table[ offset + AnimationData.TIMESTYLE ] === AnimationTimeStyle.CONTINIOUS ) ? elapsedTime : elapsedPausedTime;
 			const startTime = table[ offset + AnimationData.STARTTIME ];
 
@@ -315,11 +311,47 @@ export class PronotronAnimator
 				this._removeAnimationByInternalID( internalID );
 
 				// Re-examine this slot 
-				// It now holds the swapped-in element
+				// It now holds the swapped-in element (swap-remove pattern in NativeControlTable)
 				i--;
 
 			}
 		}
+	}
+
+	/**
+	 * Shifts a single animation's start/end window backwards by `seconds`, simulating
+	 * that much elapsed time for the given animation.
+	 *
+	 * Pending animations whose shifted start has already passed will fire onBegin on
+	 * the next tick(); ones whose shifted end has passed will fire onRender (with a
+	 * fully-advanced timeline, since (currentTime - startTime)/duration grows correctly
+	 * when startTime moves into the past) followed by onEnd and removal — all within
+	 * that one tick(), no extra bookkeeping.
+	 *
+	 * No-op if the animation already finished/was removed.
+	 */
+	fastForward( animationID: AnimationClientID, seconds: number ): void
+	{
+		if ( ! this.has( animationID ) ){
+			return;
+		}
+
+		const startTime = this._controlTable.getData( animationID, AnimationData.STARTTIME );
+		const endTime = this._controlTable.getData( animationID, AnimationData.ENDTIME );
+
+		this._controlTable.modifyByID( animationID, {
+			[ AnimationData.STARTTIME ]: startTime - seconds,
+			[ AnimationData.ENDTIME ]: endTime - seconds,
+		} );
+	}
+
+	/**
+	 * Checks if an animation with the given client ID is currently scheduled or running.
+	 * Lets orchestration layers (chains, groups) query state without reaching into internals.
+	 */
+	has( animationID: AnimationClientID ): boolean
+	{
+		return this._controlTable.isExist( animationID );
 	}
 
 	/**

--- a/packages/pronotron-utils/src/animator/PronotronAnimator.ts
+++ b/packages/pronotron-utils/src/animator/PronotronAnimator.ts
@@ -310,9 +310,14 @@ export class PronotronAnimator
 			 * Check if the animation is finished.
 			 */
 			if ( time > table[ offset + AnimationData.ENDTIME ] ){
+				
 				animationReference.onEnd?.( false );
 				this._removeAnimationByInternalID( internalID );
+
+				// Re-examine this slot 
+				// It now holds the swapped-in element
 				i--;
+
 			}
 		}
 	}

--- a/packages/pronotron-utils/src/native-control-table/NativeControlTable.ts
+++ b/packages/pronotron-utils/src/native-control-table/NativeControlTable.ts
@@ -111,11 +111,14 @@ export class NativeControlTable<EnumType extends number>
 		}
 
 		const availableSlotPosition = this._findEmptySlotPosition();
-		const emptyOffset = availableSlotPosition * this.stride;
 
-		// Object keys are always coerced to strings when you use the object literal syntax
-		for ( const [ key, value ] of Object.entries<number>( fullData ) ){
-			this.table[ emptyOffset + Number( key ) ] = value;
+		// Dedicated raw write loop. 
+		// Faster than modifyByPosition and protects against ghost-data leaks.
+		const emptyOffset = availableSlotPosition * this.stride;
+		const record = fullData as Record<number, number>;
+
+		for ( let i = 0; i < this.stride; i++ ) {
+			this.table[ emptyOffset + i ] = record[ i ]; 
 		}
 
 		this._slotIDToSlotPosition.set( ID, availableSlotPosition );
@@ -188,9 +191,11 @@ export class NativeControlTable<EnumType extends number>
 	/**
 	 * Modifies an existing slot identified by its ID with partial or complete data.
 	 * 
+	 * @note
+	 * Prefer direct table writes inside tick() for hot-path updates.
+	 * 
 	 * @param ID Slot ID to modify.
 	 * @param data Object with at least one property defined
-	 * @returns 
 	 */
 	modifyByID( ID: SlotID, data: RequireAtLeastOne<EnumValueMap<EnumType>> ): void
 	{
@@ -201,6 +206,10 @@ export class NativeControlTable<EnumType extends number>
 	/**
 	 * Updates a slot’s data when its table index (position) is already known.
 	 * Useful for internal iteration or when the ID-to-position mapping is already available.
+	 *
+	 * @note
+	 * Prefer direct table writes inside tick() for hot-path updates.
+	 * This method is intended for external callers, not internal animation logic.
 	 * 
 	 * @param position Index of the slot in the table.
 	 * @param data Partial or full node data.
@@ -208,10 +217,16 @@ export class NativeControlTable<EnumType extends number>
 	modifyByPosition( position: number, data: RequireAtLeastOne<EnumValueMap<EnumType>> ): void
 	{
 		const offset = position * this.stride;
+		const record = data as Record<number, number | undefined>;
 
-		// Object keys are always coerced to strings when you use the object literal syntax
-		for ( const [ key, value ] of Object.entries<number>( data ) ){
-			this.table[ offset + Number( key ) ] = value;
+		for ( let i = 0; i < this.stride; i++ ){
+			
+			const value = record[ i ];
+			
+			if ( value !== undefined ){
+				this.table[ offset + i ] = value;
+			}
+			
 		}
 	}
 
@@ -231,6 +246,8 @@ export class NativeControlTable<EnumType extends number>
 	 * 
 	 * @param ID Slot ID
 	 * @returns Error or SlotPosition
+	 * 
+	 * @internal
 	 */
 	private _getSlotPositionOrThrowError( ID: SlotID ): SlotPosition
 	{

--- a/packages/pronotron-utils/src/native-control-table/NativeControlTable.ts
+++ b/packages/pronotron-utils/src/native-control-table/NativeControlTable.ts
@@ -113,11 +113,11 @@ export class NativeControlTable<EnumType extends number>
 		const availableSlotPosition = this._findEmptySlotPosition();
 
 		// Dedicated raw write loop. 
-		// Faster than modifyByPosition and protects against ghost-data leaks.
+		// Faster than modifyByPosition() and protects against ghost-data leaks.
 		const emptyOffset = availableSlotPosition * this.stride;
 		const record = fullData as Record<number, number>;
 
-		for ( let i = 0; i < this.stride; i++ ) {
+		for ( let i = 0; i < this.stride; i++ ){
 			this.table[ emptyOffset + i ] = record[ i ]; 
 		}
 

--- a/packages/pronotron-utils/src/utils/IDPool.ts
+++ b/packages/pronotron-utils/src/utils/IDPool.ts
@@ -1,99 +1,93 @@
+type AllowedIDTable = Uint8Array | Uint16Array | Uint32Array;
+
 /**
  * IDPool
  * 
- * Manages a pool of unique numeric IDs, providing efficient allocation and release of IDs using an internal bit array.
+ * Manages a pool of unique numeric IDs, providing efficient allocation and release of IDs using a pre-allocated stack.
  * Supports automatic capacity expansion when all IDs are in use.
+ *  
+ * Uses LIFO stack for performance, so use it when you not need human-readability.
  * 
  * @example
  * ```typescript
- * const idPool = new IDPool();
+ * // Initialize with a capacity hint of 1024 IDs, backed by a Uint16Array (up to 65535)
+ * const idPool = new IDPool( 1024, Uint16Array );
  * const availableID: number = idPool.get();
- * idPool.consume( availableID );
  * idPool.release( availableID );
  * ```
  */
 export class IDPool
 {
-	/** @internal */
+	/**
+	 * A typed array acting as a fast LIFO stack for recycled IDs
+	 * @internal
+	 */
+	private _freeStack: AllowedIDTable;
+
+	/**
+	 * Total capacity of the pool
+	 * @internal
+	 */
 	private _capacity: number;
 
 	/**
-	 * We will store only 0 | 1 to define used or not
+	 * Tracks the highest ID that has ever been issued natively
 	 * @internal
 	 */
-	private _availableIDs: Uint8Array;
+	private _freeTop = 0;
 
-	/**
-	 * Initializes the IDPool with a given initial capacity.
-	 * 
-	 * @param capacityHint Initial number of IDs available; the pool will expand dynamically if needed.
-	 */
-	constructor( capacityHint: number )
+	constructor( capacityHint: number, tableType: { new ( length: number ): AllowedIDTable } = Uint16Array )
 	{
 		this._capacity = capacityHint;
-		this._availableIDs = new Uint8Array( capacityHint );
+		this._freeTop = capacityHint;
+
+		this._freeStack = new tableType( capacityHint );
+
+		// Pre-fill stack: [0, 1, 2, ..., N-1]
+		for ( let i = 0; i < capacityHint; i++ ){
+			this._freeStack[ i ] = i;
+		}
 	}
 
 	/**
-	 * Returns the first available numeric ID from the pool. 
-	 * If all IDs are used, the pool automatically expands and returns the next available ID.
-	 * 
-	 * ***Returned ID must be used with IDPool.consume( ID )***
-	 * 
-	 * @returns The available ID as a number.
+	 * Returns an ID from the pool.
 	 */
 	get(): number
 	{
-		// Search for first available ID
-		for ( let i = 0; i < this._availableIDs.length; i++ ){
-			if ( ! this._availableIDs[ i ] ){
-				return i;
-			}
+		if ( this._freeTop === 0 ){
+			this._expandCapacity();
 		}
 
-		// Hold current capacity, to return after expanding
-		const last = this._capacity;
-
-		this._expandCapacity();
-		return last;
+		return this._freeStack[ --this._freeTop ];
 	}
 
 	/**
-	 * Marks a specific ID as used in the pool.
-	 * 
-	 * @param ID Numeric ID to mark as consumed.
-	 */
-	consume( ID: number ): void
-	{
-		this._availableIDs[ ID ] = 1;
-	}
-
-	/**
-	 * Releases a previously consumed ID, making it available for future allocation.
-	 * 
-	 * @param ID Numeric ID to release.
+	 * Pushes given ID back onto the pool.
+	 * @param ID 
 	 */
 	release( ID: number ): void
 	{
-		this._availableIDs[ ID ] = 0;
+		// O(1) Push: Add the recycled ID back onto the stack
+		this._freeStack[ this._freeTop++ ] = ID;
 	}
 
 	/**
-	 * Doubles the internal storage capacity of the pool when all IDs are in use.
-	 * Copies existing ID usage state to the new storage.
-	 * 
+	 * Doubles the internal storage capacity of the pool.
 	 * @internal
 	 */
 	private _expandCapacity(): void
 	{
 		const newCapacity = this._capacity * 2;
+		const newStack = new ( this._freeStack.constructor as { new ( length: number ): AllowedIDTable } )( newCapacity );
 
-		// Create new array with increased size
-		const newAvailableIDsTable = new Uint8Array( newCapacity );
-		newAvailableIDsTable.set( this._availableIDs );
+		newStack.set( this._freeStack );
 
-		// Update references and capacity
-		this._availableIDs = newAvailableIDsTable;
+		// Push the newly added IDs onto the free stack
+		for ( let i = this._capacity; i < newCapacity; i++ ) {
+			newStack[ this._freeTop++ ] = i;
+		}
+
+		this._freeStack = newStack;
 		this._capacity = newCapacity;
 	}
 }

--- a/packages/pronotron-utils/tests/IDPool.test.ts
+++ b/packages/pronotron-utils/tests/IDPool.test.ts
@@ -1,7 +1,6 @@
-// IDPool.test.ts
-import { IDPool } from "../src/utils/IDPool"; // adjust path if needed
+import { IDPool } from "../src/utils/IDPool";
 
-describe( "IDPool (unit)", () => {
+describe( "IDPool (LIFO Stack Version)", () => {
 
 	let pool: IDPool;
 
@@ -9,78 +8,68 @@ describe( "IDPool (unit)", () => {
 		pool = new IDPool( 3 ); // small initial capacity for tests
 	} );
 
-	test( "get() returns lowest available id and consume marks it used", () => {
+	test( "get() returns IDs from the top of the stack in LIFO order", () => {
 
-		const a = pool.get();
-		expect( a ).toBe( 0 );
-		pool.consume( a );
-
-		const b = pool.get();
-		expect( b ).toBe( 1 );
-		pool.consume( b );
-
-		const c = pool.get();
-		expect( c ).toBe( 2 );
-		pool.consume( c );
+		// Stack is initialized as [0, 1, 2] with top at 3.
+		// get() pops from the top, so it returns 2 -> 1 -> 0.
+		expect( pool.get() ).toBe( 2 );
+		expect( pool.get() ).toBe( 1 );
+		expect( pool.get() ).toBe( 0 );
 
 	} );
 
-	test( "when all ids used get() expands capacity and returns next id (old capacity)", () => {
+	test( "when all ids are used, get() expands capacity and pops the newest minted ID", () => {
 
-		// Fill initial capacity (3)
-		pool.consume( pool.get() ); // 0
-		pool.consume( pool.get() ); // 1
-		pool.consume( pool.get() ); // 2
+		// Empty the initial pool
+		pool.get(); // 2
+		pool.get(); // 1
+		pool.get(); // 0
 
-		// Now all used. Next get should return 3 (old capacity) and trigger expansion.
-		const next = pool.get();
-		expect( next ).toBe( 3 );
-
-		// After expansion, subsequent get returns 4 (next free)
-		pool.consume( next );
-
-		const next2 = pool.get();
-		expect( next2 ).toBe( 4 );
+		// Pool is empty. Next get() triggers expansion to capacity 6.
+		// It pushes [3, 4, 5] onto the stack and pops the top one (5).
+		expect( pool.get() ).toBe( 5 );
+		
+		// Subsequent gets return the rest of the newly minted chunk
+		expect( pool.get() ).toBe( 4 );
+		expect( pool.get() ).toBe( 3 );
 
 	} );
 
-	test( "release() frees id and get() returns lowest freed id", () => {
+	test( "release() pushes ID back to stack, making it the very next ID returned", () => {
 
-		const ids: number[] = [];
+		const id1 = pool.get(); // 2
+		const id2 = pool.get(); // 1
+		pool.get();             // 0
 
-		ids.push( pool.get() ); pool.consume( ids[ 0 ] ); // 0
-		ids.push( pool.get() ); pool.consume( ids[ 1 ] ); // 1
-		ids.push( pool.get() ); pool.consume( ids[ 2 ] ); // 2
+		// Release 1, then release 2.
+		// Stack top receives 1, then 2.
+		pool.release( id2 );
+		pool.release( id1 );
 
-		// Expand once
-		const id3 = pool.get(); pool.consume( id3 ); // 3
-
-		// Release id 1 and 0, should be reused in get()
-		pool.release( 1 );
-		const reused = pool.get();
-		expect( reused ).toBe( 1 );
-
-		// Release 0 and expect next get to return 0 (lowest available)
-		pool.release( 0 );
-		const reused0 = pool.get();
-		expect( reused0 ).toBe( 0 );
+		// Next get() should pop the LAST released ID (LIFO: 2)
+		expect( pool.get() ).toBe( id1 ); // 2
+		
+		// Next get() should pop the preceding released ID (1)
+		expect( pool.get() ).toBe( id2 ); // 1
 
 	} );
 
-	test( "multiple expansions double capacity each time (behavioral check)", () => {
+	test( "multiple expansions double capacity and manage the LIFO chunks correctly", () => {
 
 		// Start capacity = 1 to force multiple expansions quickly
 		const small = new IDPool( 1 );
 		const got: number[] = [];
 		
-		// consume a bunch to force expansions: 0..7
 		for ( let i = 0; i < 8; i++ ) {
-			const id = small.get();
-			got.push( id );
-			small.consume( id );
+			got.push( small.get() );
 		}
-		// We expect returned ids are sequential starting at 0
-		expect( got ).toEqual( [ 0, 1, 2, 3, 4, 5, 6, 7 ] );
+		
+		// Expected LIFO extraction sequence:
+		// Cap 1: prefilled [0]          -> pops 0
+		// Exp 2: pushes [1]             -> pops 1
+		// Exp 4: pushes [2, 3]          -> pops 3, then 2
+		// Exp 8: pushes [4, 5, 6, 7]    -> pops 7, 6, 5, 4
+		expect( got ).toEqual( [ 0, 1, 3, 2, 7, 6, 5, 4 ] );
 
 	} );
 } );

--- a/packages/pronotron-utils/tests/PronotronAnimator.test.ts
+++ b/packages/pronotron-utils/tests/PronotronAnimator.test.ts
@@ -169,4 +169,86 @@ describe( "PronotronAnimator (unit)", () =>
 
 	} );
 
+	/**
+	 * Parametrized suite that verifies exact callback fire counts for N concurrent animations.
+	 * 
+	 * Tests the NativeControlTable swap-remove integrity by ensuring an early-terminating 
+	 * animation correctly exits without causing ghost reads or skipping newly swapped slots.
+	 */
+	describe( 'Callback fire counts across N concurrent animations (Swap-Remove Integrity)', () => {
+
+		const testCases = [
+			[ 2,  'start', 0 ],
+			[ 2,  'end',   1 ],
+			[ 3,  'start', 0 ],
+			[ 3,  'mid',   1 ],
+			[ 3,  'end',   2 ],
+			[ 5,  'start', 0 ],
+			[ 5,  'mid',   2 ],
+			[ 5,  'end',   4 ],
+			[ 10, 'start', 0 ],
+			[ 10, 'mid',   4 ],
+			[ 10, 'end',   9 ],
+		];
+
+		it.each( testCases )( 'N=%i, finishing from %s (index %i)', ( N, position, shortIndex ) => {
+
+			// Single mock functions that capture the index of the caller
+			const mockBegin  = jest.fn();
+			const mockRender = jest.fn();
+			const mockEnd    = jest.fn();
+
+			// Setup baseline time
+			now.mockReturnValue( 0 );
+			clock.tick();
+			animator.tick(); 
+
+			// Populate NativeControlTable
+			for ( let i = 0; i < N; i++ ){
+
+				const isShort = i === shortIndex;
+				
+				animator.add( {
+					id: isShort ? 'short' : `long-${ i }`,
+					autoPause: false,
+					duration: isShort ? 1 : 10,
+					onBegin:  () => mockBegin( i ),
+					onRender: () => mockRender( i ),
+					onEnd:    () => mockEnd( i ),
+				} );
+
+			}
+
+			// Tick 1: 'short' ends (duration 1s), triggering the swap-remove
+			now.mockReturnValue( 1.1 * 1000 );
+			clock.tick();
+			animator.tick();
+
+			// Tick 2: verifies 'long' animations survive the swap and continue ticking
+			now.mockReturnValue( 2.0 * 1000 );
+			clock.tick();
+			animator.tick();
+
+			// --- ASSERTIONS ---
+
+			// Every single animation should begin exactly once. No duplicates.
+			expect( mockBegin ).toHaveBeenCalledTimes( N );
+
+			// Only the 'short' animation ends, and it ends exactly once.
+			expect( mockEnd ).toHaveBeenCalledTimes( 1 );
+			expect( mockEnd ).toHaveBeenCalledWith( shortIndex );
+
+			// Render count math:
+			// - The 1 'short' animation renders exactly once (in Tick 1).
+			// - The N-1 'long' animations render twice (in Tick 1 and Tick 2).
+			// - Total expected renders: 1 + (N - 1) * 2 = 2N - 1
+			expect( mockRender ).toHaveBeenCalledTimes( 2 * N - 1 );
+
+			// Ensure the short animation wasn't accidentally kept alive and rendered in Tick 2
+			expect( mockRender ).not.toHaveBeenLastCalledWith( shortIndex );
+
+		} );
+
+	} );
+
 } );

--- a/packages/pronotron-utils/tests/PronotronAnimator.test.ts
+++ b/packages/pronotron-utils/tests/PronotronAnimator.test.ts
@@ -1,3 +1,4 @@
+import { describe } from "node:test";
 import { PronotronAnimator } from "../src/animator/PronotronAnimator";
 import { PronotronClock } from "../src/clock/PronotronClock";
 
@@ -21,12 +22,14 @@ describe( "PronotronAnimator (unit)", () =>
 		
 		it( 'add() registers animation' , () => {
 
+			expect( animator.has( 'REGISTER_TEST' ) ).toBe( false );
+
 			const onBegin = jest.fn();
 			const onRender = jest.fn();
 			const onEnd = jest.fn();
 
 			animator.add( {
-				id: "anim-1",
+				id: "REGISTER_TEST",
 				autoPause: false,
 				duration: 1,
 				delay: 0.5,
@@ -40,6 +43,8 @@ describe( "PronotronAnimator (unit)", () =>
 			expect( onRender ).not.toHaveBeenCalled();
 			expect( onEnd ).not.toHaveBeenCalled();
 
+			expect( animator.has( 'REGISTER_TEST' ) ).toBe( true );
+
 		} );
 
 		it( 'adding duplicate id removes previous animation (forced) before adding new', () => {
@@ -48,7 +53,7 @@ describe( "PronotronAnimator (unit)", () =>
 			const onEndSecond = jest.fn();
 
 			animator.add( {
-				id: "dup",
+				id: "DUPLICATE_TEST",
 				duration: 1,
 				autoPause: false,
 				onBegin: jest.fn(),
@@ -58,7 +63,7 @@ describe( "PronotronAnimator (unit)", () =>
 
 			// second add with same client id: should force-remove first
 			animator.add( {
-				id: "dup",
+				id: "DUPLICATE_TEST",
 				duration: 0.5,
 				autoPause: false,
 				onBegin: jest.fn(),
@@ -78,7 +83,7 @@ describe( "PronotronAnimator (unit)", () =>
 			const onEnd = jest.fn();
 
 			animator.add( {
-				id: "anim-4",
+				id: "REMOVE_TEST",
 				duration: 1,
 				delay: 0,
 				autoPause: false,
@@ -87,10 +92,12 @@ describe( "PronotronAnimator (unit)", () =>
 				onEnd,
 			} );
 
-			animator.remove( "anim-4", true );
+			animator.remove( "REMOVE_TEST", true );
 
 			// remove(id, true) should execute onEnd(forced: true)
 			expect( onEnd ).toHaveBeenCalledWith( true );
+
+			expect( animator.has( 'REMOVE_TEST' ) ).toBe( false );
 
 		} );
 
@@ -99,7 +106,7 @@ describe( "PronotronAnimator (unit)", () =>
 			// Adding another node with same ref should warn and return false
 			const warnSpy = jest.spyOn( console, "warn" ).mockImplementation( () => {} );
 
-			animator.remove( "i-do-not-exist", true );
+			animator.remove( "I_DO_NOT_EXIST", true );
 
 			expect( warnSpy ).toHaveBeenCalled();
 
@@ -124,7 +131,7 @@ describe( "PronotronAnimator (unit)", () =>
 			animator.tick();
 
 			animator.add( {
-				id: "anim-2",
+				id: "TEST_ANIMATION",
 				duration: 2,
 				delay: 1,
 				autoPause: false,
@@ -249,6 +256,136 @@ describe( "PronotronAnimator (unit)", () =>
 
 		} );
 
+	} );
+
+	describe( 'Non-renderable animations (delay + onBegin only, no onRender/duration)', () => {
+ 
+		it( 'fires onBegin once and onEnd(false) once, without ever touching onRender', () => {
+ 
+			const onBegin = jest.fn();
+			const onEnd = jest.fn();
+ 
+			now.mockReturnValue( 0 );
+			clock.tick();
+			animator.tick();
+ 
+			// No `onRender`, no `duration` - this is the NonRenderableAnimation shape
+			// (e.g. a pure "wait then fire a callback" chain step).
+			animator.add( {
+				id: "non-renderable-1",
+				delay: 1,
+				autoPause: false,
+				onBegin,
+				onEnd,
+			} );
+ 
+			// reaches startTime (1s): onBegin fires; RENDERABLE is 0, so the table-driven
+			// tick() loop must skip the onRender call entirely instead of throwing on
+			// a missing function.
+			now.mockReturnValue( 1.0 * 1000 );
+			clock.tick();
+			animator.tick();
+ 
+			expect( onBegin ).toHaveBeenCalledTimes( 1 );
+			expect( onEnd ).not.toHaveBeenCalled();
+			expect( animator.has( "non-renderable-1" ) ).toBe( true );
+ 
+			// duration defaults to 0, so endTime === startTime; the next tick once
+			// time has moved past that instant finishes it naturally.
+			now.mockReturnValue( 1.1 * 1000 );
+			clock.tick();
+			animator.tick();
+ 
+			expect( onEnd ).toHaveBeenCalledTimes( 1 );
+			expect( onEnd ).toHaveBeenCalledWith( false );
+			expect( animator.has( "non-renderable-1" ) ).toBe( false );
+ 
+		} );
+ 
+	} );
+
+	describe( "fastForward()", () => {
+
+		it( 'is a no-op for an ID that does not exist (does not throw, no warning)', () => {
+ 
+			const warnSpy = jest.spyOn( console, "warn" ).mockImplementation( () => {} );
+ 
+			expect( () => animator.fastForward( "ghost", 5 ) ).not.toThrow();
+			expect( animator.has( "ghost" ) ).toBe( false );
+ 
+			// Unlike remove(), an unknown ID is expected (e.g. a chain step that
+			// already finished naturally), so this should stay silent.
+			expect( warnSpy ).not.toHaveBeenCalled();
+ 
+			warnSpy.mockRestore();
+ 
+		} );
+
+		it( 'produces a correctly advanced timeline when only partially fast-forwarded', () => {
+ 
+			const onBegin = jest.fn();
+			const onRender = jest.fn();
+			const onEnd = jest.fn();
+ 
+			now.mockReturnValue( 0 );
+			clock.tick();
+			animator.tick();
+ 
+			animator.add( {
+				id: "TEST_FAST_FORWARD",
+				duration: 4,
+				delay: 0, // window: [0, 4]
+				autoPause: false,
+				onBegin,
+				onRender,
+				onEnd,
+			} );
+ 
+			// jump 1s into the animation without advancing the global clock
+			animator.fastForward( "TEST_FAST_FORWARD", 1 );
+ 
+			clock.tick();
+			animator.tick();
+ 
+			// currentTime(0) - startTime(-1) = 1s elapsed of a 4s duration
+			expect( onRender ).toHaveBeenCalledWith( 0, -1, 4 );
+			expect( onEnd ).not.toHaveBeenCalled();
+			expect( animator.has( "TEST_FAST_FORWARD" ) ).toBe( true );
+ 
+		} );
+		
+	} );
+
+	describe( 'Internal capacity expansion', () => {
+ 
+		it( 'keeps working correctly once more animations are added than the initial capacity hint', () => {
+ 
+			// Capacity hint of 2: adding a 3rd concurrent animation forces both the
+			// internal IDPool and NativeControlTable to expand past their starting size.
+			const smallAnimator = new PronotronAnimator( clock, 2 );
+ 
+			const onBegin = jest.fn();
+			const onRender = jest.fn();
+ 
+			now.mockReturnValue( 0 );
+			clock.tick();
+ 
+			smallAnimator.add( { id: "cap-1", duration: 1, autoPause: false, onBegin: jest.fn(), onRender: jest.fn(), onEnd: jest.fn() } );
+			smallAnimator.add( { id: "cap-2", duration: 1, autoPause: false, onBegin: jest.fn(), onRender: jest.fn(), onEnd: jest.fn() } );
+ 
+			// this 3rd add exceeds the capacity hint of 2 and triggers expansion
+			smallAnimator.add( { id: "cap-3", duration: 1, autoPause: false, onBegin, onRender, onEnd: jest.fn() } );
+ 
+			expect( smallAnimator.has( "cap-3" ) ).toBe( true );
+ 
+			smallAnimator.tick();
+ 
+			// the expanded slot must behave identically to any other slot
+			expect( onBegin ).toHaveBeenCalledTimes( 1 );
+			expect( onRender ).toHaveBeenCalledTimes( 1 );
+ 
+		} );
+ 
 	} );
 
 } );

--- a/packages/pronotron-utils/tests/PronotronAnimator.test.ts
+++ b/packages/pronotron-utils/tests/PronotronAnimator.test.ts
@@ -20,7 +20,7 @@ describe( "PronotronAnimator (unit)", () =>
 
 	describe( 'Initialization', () => {
 		
-		it( 'add() registers animation' , () => {
+		it( 'add() registers animation', () => {
 
 			expect( animator.has( 'REGISTER_TEST' ) ).toBe( false );
 
@@ -219,9 +219,9 @@ describe( "PronotronAnimator (unit)", () =>
 					id: isShort ? 'short' : `long-${ i }`,
 					autoPause: false,
 					duration: isShort ? 1 : 10,
-					onBegin:  () => mockBegin( i ),
+					onBegin: () => mockBegin( i ),
 					onRender: () => mockRender( i ),
-					onEnd:    () => mockEnd( i ),
+					onEnd: () => mockEnd( i ),
 				} );
 
 			}


### PR DESCRIPTION
## Summary
This PR fixes a iteration bug in `PronotronAnimator.tick()`, replaces `IDPool`'s linear scan with an O(1) LIFO stack, removes `Object.entries()` allocation overhead from `NativeControlTable`, and adds a `fastForward()` / `has()` API to the animator (the building block for chain/group-style sequencing). 
Test coverage was extended alongside each change. 

Version bumps for `@pronotron/utils`, `@pronotron/io`, and `@pronotron/pointer` are included via changesets.

## What's changed

### Fix
- **`5267533`** — `fix(animator): fix ghost memory offset in tick(), add test suite` `tick()` cached `usedSlots` and destructured it once at the top of the loop. Since `usedSlots` mutates mid-iteration (the internal swap-remove pattern moves the last slot into a freed one), the stale bound either skipped re-checking a freshly swapped-in element or let the loop read past the live range. Fixed by reading `this._controlTable.usedSlots` live each pass and decrementing `i` after a removal so the swapped-in element gets re-examined on the next iteration. Added a parametrized `it.each` suite (N=2..10, finishing from start/mid/end) that pins down exact `onBegin`/`onRender`/`onEnd` call counts to catch regressions here.

### Performance
- **`00fe5e2`** — `refactor(IDPool): increase performance` Replaced the `Uint8Array` "used/unused" bitmap + linear scan with a pre-allocated LIFO free-stack (`get()`/`release()` are now O(1) push/pop instead of an O(n) scan). `consume()` is gone — `get()` now implicitly marks the ID in-use, since popping it off the stack *is* consuming it. Constructor gains a `tableType` param (`Uint8Array | Uint16Array | Uint32Array`, defaults to `Uint16Array`), bumping the safe default ID ceiling from 255 to 65,535. **Note: ID reuse order changed from lowest-first to most-recently-released-first (LIFO)** — harmless for `PronotronAnimator`, where IDs are opaque, but worth knowing if anything else depended on ordering.
- **`ece3e74`** + **`36859f3`** — `refactor(NativeControlTable): implement allocation-free iteration` `add()` and `modifyByPosition()` swapped `Object.entries(fullData)`.

### Feature
- **`ac6d566`** — `feature(Animator): add fast-forward feature, extend tests`
  - `fastForward(id, seconds)`: shifts a single animation's stored `STARTTIME`/`ENDTIME` backwards by `seconds`, independent of the global clock. A pending animation whose shifted start has passed fires `onBegin` on the next `tick()`; one whose shifted end has passed resolves `onBegin` → `onRender` (correctly advanced timeline) → `onEnd(false)` in that same tick. No-op (silently) on an unknown ID.
  - `has(id)`: O(1) existence check, used internally by `add()`'s duplicate-ID guard (replacing a direct reach into `_controlTable.isExist()`) and externally by orchestration code that wants to query state without touching internals.